### PR TITLE
feat: replace browser-side GitHub token with secure server-side admin API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+node_modules/
+admin-api/node_modules/
+.env
+admin-api/.env

--- a/README.md
+++ b/README.md
@@ -11,3 +11,27 @@ npm run check:all
 ```
 
 The validator checks menu/config/combo JSON shape, translations, prices, image URLs, duplicate IDs, and combo item references.
+
+## Password-only admin publishing
+
+The admin panel now supports a token-free browser experience:
+
+- admins sign in with a password only
+- the real GitHub write token stays on a small backend service
+- `admin.html` talks to that backend for publish, image upload, image listing, and image delete operations
+
+The backend lives in `admin-api/`.
+
+### Local setup
+
+1. Fill in the root `.env` placeholders or create `admin-api/.env`
+2. Start the API from `admin-api/`
+3. Point the admin page to that API using either:
+   - the one-time `Admin API URL` field on the login screen, or
+   - `admin-config.js` for a deployed environment
+
+### Important
+
+- Keep `LV_GITHUB_TOKEN` and `LV_ADMIN_SESSION_SECRET` **server-side only**
+- Set `LV_ADMIN_ALLOWED_ORIGIN` to the exact public origin of the admin page
+- For production, use `LV_ADMIN_PASSWORD_HASH` instead of a plaintext password

--- a/admin-api/.env.example
+++ b/admin-api/.env.example
@@ -1,0 +1,11 @@
+LV_ADMIN_PASSWORD=change-me
+# Or generate a hash with: npm run hash:password -- Pierre
+# LV_ADMIN_PASSWORD_HASH=scrypt$...
+LV_ADMIN_SESSION_SECRET=replace-with-a-long-random-secret
+LV_ADMIN_SESSION_TTL_HOURS=12
+LV_ADMIN_ALLOWED_ORIGIN=https://sandgraal.github.io/las-veraneras-menu
+LV_GITHUB_TOKEN=github_pat_replace_me
+LV_GITHUB_OWNER=sandgraal
+LV_GITHUB_REPO=las-veraneras-menu
+LV_GITHUB_BRANCH=main
+LV_PUBLIC_SITE_BASE=https://sandgraal.github.io/las-veraneras-menu

--- a/admin-api/README.md
+++ b/admin-api/README.md
@@ -1,0 +1,66 @@
+# Las Veraneras Admin API
+
+Tiny password-based admin API that keeps the GitHub write token on the server instead of in each browser.
+
+## What it does
+
+- accepts **password-only** admin logins
+- stores the session in an `HttpOnly` cookie
+- writes `data/*.json` changes to GitHub
+- uploads and deletes files under `images/`
+- lists repo-hosted images for the photo library tab
+
+## Environment variables
+
+You can set these in `admin-api/.env` or in the project-root `.env` for local development:
+
+- `LV_ADMIN_PASSWORD` or `LV_ADMIN_PASSWORD_HASH`
+- `LV_ADMIN_SESSION_SECRET`
+- `LV_ADMIN_SESSION_TTL_HOURS`
+- `LV_ADMIN_ALLOWED_ORIGIN`
+- `LV_GITHUB_TOKEN`
+- `LV_GITHUB_OWNER`
+- `LV_GITHUB_REPO`
+- `LV_GITHUB_BRANCH`
+- `LV_PUBLIC_SITE_BASE`
+
+## Local run
+
+```bash
+cd admin-api
+npm start
+```
+
+The API listens on `http://localhost:8787` by default.
+
+## Password hashing
+
+For production, prefer a hash over a plaintext password:
+
+```bash
+cd admin-api
+npm run hash:password -- Pierre
+```
+
+Then set the printed value as `LV_ADMIN_PASSWORD_HASH` and remove `LV_ADMIN_PASSWORD`.
+
+## Routes
+
+- `GET /api/health`
+- `GET /api/session`
+- `POST /api/session/login`
+- `POST /api/session/logout`
+- `POST /api/publish`
+- `GET /api/images`
+- `POST /api/images`
+- `DELETE /api/images`
+
+## Deployment notes
+
+This service is intended to be deployed separately from GitHub Pages on any Node host (for example Railway, Render, Fly.io, or a small VPS).
+
+Important bits:
+
+- set `LV_ADMIN_ALLOWED_ORIGIN` to the exact public admin origin
+- keep `LV_GITHUB_TOKEN` and `LV_ADMIN_SESSION_SECRET` only on the server
+- when the admin site is on HTTPS and the API is on another origin, the cookie is sent as `SameSite=None; Secure`

--- a/admin-api/hash-password.js
+++ b/admin-api/hash-password.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const password = process.argv[2];
+if (!password) {
+  console.error("Usage: node hash-password.js <password>");
+  process.exit(1);
+}
+
+const salt = crypto.randomBytes(16);
+const hash = crypto.scryptSync(password, salt, 64);
+console.log(`scrypt$${salt.toString("base64")}$${hash.toString("base64")}`);

--- a/admin-api/package.json
+++ b/admin-api/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "hash:password": "node hash-password.js"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/admin-api/package.json
+++ b/admin-api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "las-veraneras-admin-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js",
+    "hash:password": "node hash-password.js"
+  }
+}

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -154,7 +154,12 @@ function verifySessionToken(token) {
     .update(body)
     .digest("base64url");
   if (!safeEqual(signature, expected)) return null;
-  const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
   if (!payload?.exp || payload.exp < Date.now()) return null;
   return payload;
 }

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -1,0 +1,542 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const http = require("http");
+const crypto = require("crypto");
+
+loadEnvFile(path.join(__dirname, ".env"));
+loadEnvFile(path.join(__dirname, "..", ".env"));
+
+const PORT = Number(process.env.PORT || 8787);
+const SESSION_COOKIE_NAME = "lv_admin_session";
+const IMAGE_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/i;
+const IMAGE_PATH_RE = /^images\/[a-z0-9._-]+$/i;
+const IMAGE_FILE_RE = /\.(jpe?g|png|webp|gif|svg|heic)$/i;
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const raw = fs.readFileSync(filePath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+function config() {
+  return {
+    password: process.env.LV_ADMIN_PASSWORD || "",
+    passwordHash: process.env.LV_ADMIN_PASSWORD_HASH || "",
+    sessionSecret: process.env.LV_ADMIN_SESSION_SECRET || "",
+    sessionTtlHours: Number(process.env.LV_ADMIN_SESSION_TTL_HOURS || 12),
+    allowedOrigins: String(process.env.LV_ADMIN_ALLOWED_ORIGIN || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    githubToken: process.env.LV_GITHUB_TOKEN || "",
+    owner: process.env.LV_GITHUB_OWNER || "",
+    repo: process.env.LV_GITHUB_REPO || "",
+    branch: process.env.LV_GITHUB_BRANCH || "main",
+    publicSiteBase: String(process.env.LV_PUBLIC_SITE_BASE || "").replace(
+      /\/+$/,
+      "",
+    ),
+  };
+}
+
+function safeEqual(a, b) {
+  const aBuf = Buffer.from(String(a || ""));
+  const bBuf = Buffer.from(String(b || ""));
+  if (aBuf.length !== bBuf.length) return false;
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+function verifyScryptHash(password, encoded) {
+  const [scheme, saltB64, hashB64] = String(encoded || "").split("$");
+  if (scheme !== "scrypt" || !saltB64 || !hashB64) return false;
+  const derived = crypto
+    .scryptSync(password, Buffer.from(saltB64, "base64"), 64)
+    .toString("base64");
+  return safeEqual(derived, hashB64);
+}
+
+function verifyPassword(password) {
+  const cfg = config();
+  if (cfg.passwordHash) return verifyScryptHash(password, cfg.passwordHash);
+  if (!cfg.password) throw new Error("LV_ADMIN_PASSWORD no está configurada.");
+  return safeEqual(password, cfg.password);
+}
+
+function requireServerConfig() {
+  const cfg = config();
+  if (!cfg.sessionSecret) {
+    throw new Error("LV_ADMIN_SESSION_SECRET no está configurada.");
+  }
+  if (!cfg.githubToken) {
+    throw new Error("LV_GITHUB_TOKEN no está configurado.");
+  }
+  if (!cfg.owner || !cfg.repo) {
+    throw new Error("LV_GITHUB_OWNER y LV_GITHUB_REPO son obligatorios.");
+  }
+  if (!cfg.password && !cfg.passwordHash) {
+    throw new Error(
+      "Debes configurar LV_ADMIN_PASSWORD o LV_ADMIN_PASSWORD_HASH.",
+    );
+  }
+  return cfg;
+}
+
+function shouldUseSecureCookies(req) {
+  const origin = String(req.headers.origin || "");
+  const forwardedProto = String(req.headers["x-forwarded-proto"] || "");
+  return origin.startsWith("https://") || forwardedProto.includes("https");
+}
+
+function makeCookie(req, value, maxAgeSeconds) {
+  const parts = [
+    `${SESSION_COOKIE_NAME}=${value}`,
+    "Path=/",
+    "HttpOnly",
+    `Max-Age=${maxAgeSeconds}`,
+  ];
+  if (shouldUseSecureCookies(req)) {
+    parts.push("SameSite=None", "Secure");
+  } else {
+    parts.push("SameSite=Lax");
+  }
+  return parts.join("; ");
+}
+
+function clearCookie(req) {
+  const parts = [`${SESSION_COOKIE_NAME}=`, "Path=/", "HttpOnly", "Max-Age=0"];
+  if (shouldUseSecureCookies(req)) {
+    parts.push("SameSite=None", "Secure");
+  } else {
+    parts.push("SameSite=Lax");
+  }
+  return parts.join("; ");
+}
+
+function createSessionToken() {
+  const cfg = requireServerConfig();
+  const now = Date.now();
+  const payload = {
+    sub: "admin",
+    user: "Las Veraneras Admin",
+    iat: now,
+    exp: now + cfg.sessionTtlHours * 60 * 60 * 1000,
+  };
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = crypto
+    .createHmac("sha256", cfg.sessionSecret)
+    .update(body)
+    .digest("base64url");
+  return `${body}.${sig}`;
+}
+
+function verifySessionToken(token) {
+  const cfg = requireServerConfig();
+  if (!token || !String(token).includes(".")) return null;
+  const [body, signature] = String(token).split(".");
+  const expected = crypto
+    .createHmac("sha256", cfg.sessionSecret)
+    .update(body)
+    .digest("base64url");
+  if (!safeEqual(signature, expected)) return null;
+  const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  if (!payload?.exp || payload.exp < Date.now()) return null;
+  return payload;
+}
+
+function parseCookies(req) {
+  const raw = String(req.headers.cookie || "");
+  return raw.split(";").reduce((acc, part) => {
+    const idx = part.indexOf("=");
+    if (idx === -1) return acc;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (key) acc[key] = decodeURIComponent(value);
+    return acc;
+  }, {});
+}
+
+function getSession(req) {
+  const cookies = parseCookies(req);
+  return verifySessionToken(cookies[SESSION_COOKIE_NAME]);
+}
+
+function isOriginAllowed(origin) {
+  const cfg = config();
+  if (!origin) return true;
+  if (!cfg.allowedOrigins.length) return true;
+  return cfg.allowedOrigins.includes(origin);
+}
+
+function applyCors(res, req) {
+  const origin = String(req.headers.origin || "");
+  if (origin && isOriginAllowed(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    res.setHeader("Vary", "Origin");
+  }
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Accept, X-Requested-With",
+  );
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
+}
+
+function sendJson(res, req, statusCode, payload, extraHeaders = {}) {
+  applyCors(res, req);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    ...extraHeaders,
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function notFound(res, req) {
+  sendJson(res, req, 404, { error: "Ruta no encontrada." });
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+function encodeGitHubPath(filePath) {
+  return filePath
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+}
+
+async function githubFetch(apiPath, options = {}) {
+  const cfg = requireServerConfig();
+  const url = `https://api.github.com${apiPath}`;
+  const headers = {
+    Authorization: `Bearer ${cfg.githubToken}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    ...(options.body ? { "Content-Type": "application/json" } : {}),
+    ...(options.headers || {}),
+  };
+  const res = await fetch(url, {
+    method: options.method || "GET",
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+  const text = await res.text();
+  let data = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch (e) {
+    data = null;
+  }
+  if (!res.ok) {
+    const err = new Error(
+      data?.message || text || `GitHub respondió ${res.status}`,
+    );
+    err.status = res.status;
+    throw err;
+  }
+  return data;
+}
+
+async function getFileSha(filePath) {
+  const cfg = requireServerConfig();
+  try {
+    const data = await githubFetch(
+      `/repos/${cfg.owner}/${cfg.repo}/contents/${encodeGitHubPath(filePath)}?ref=${encodeURIComponent(cfg.branch)}`,
+    );
+    return data?.sha || null;
+  } catch (e) {
+    if (e.status === 404) return null;
+    throw e;
+  }
+}
+
+async function putTextFile(filePath, content, message) {
+  const cfg = requireServerConfig();
+  const sha = await getFileSha(filePath);
+  return githubFetch(
+    `/repos/${cfg.owner}/${cfg.repo}/contents/${encodeGitHubPath(filePath)}`,
+    {
+      method: "PUT",
+      body: {
+        message,
+        branch: cfg.branch,
+        content: Buffer.from(content, "utf8").toString("base64"),
+        ...(sha ? { sha } : {}),
+      },
+    },
+  );
+}
+
+async function putBase64File(filePath, base64Data, message) {
+  const cfg = requireServerConfig();
+  const sha = await getFileSha(filePath);
+  const content = String(base64Data || "").replace(/\s+/g, "");
+  if (!/^[A-Za-z0-9+/=]+$/.test(content)) {
+    throw new Error("El archivo recibido no es base64 válido.");
+  }
+  return githubFetch(
+    `/repos/${cfg.owner}/${cfg.repo}/contents/${encodeGitHubPath(filePath)}`,
+    {
+      method: "PUT",
+      body: {
+        message,
+        branch: cfg.branch,
+        content,
+        ...(sha ? { sha } : {}),
+      },
+    },
+  );
+}
+
+async function deleteFile(filePath, sha, message) {
+  const cfg = requireServerConfig();
+  return githubFetch(
+    `/repos/${cfg.owner}/${cfg.repo}/contents/${encodeGitHubPath(filePath)}`,
+    {
+      method: "DELETE",
+      body: {
+        message,
+        branch: cfg.branch,
+        sha,
+      },
+    },
+  );
+}
+
+function buildPublicImageUrl(fileName) {
+  const cfg = config();
+  if (!cfg.publicSiteBase) return "";
+  return `${cfg.publicSiteBase}/images/${encodeURIComponent(fileName)}`;
+}
+
+async function listImages() {
+  const cfg = requireServerConfig();
+  const files = await githubFetch(
+    `/repos/${cfg.owner}/${cfg.repo}/contents/images?ref=${encodeURIComponent(cfg.branch)}`,
+  );
+  const list = Array.isArray(files) ? files : [];
+  return list
+    .filter((file) => IMAGE_FILE_RE.test(file.name))
+    .map((file) => ({
+      name: file.name,
+      path: `images/${file.name}`,
+      sha: file.sha,
+      size: file.size,
+      publicUrl: buildPublicImageUrl(file.name),
+    }));
+}
+
+function requireSession(req) {
+  const session = getSession(req);
+  if (!session) {
+    const err = new Error("Sesión expirada o inexistente.");
+    err.status = 401;
+    throw err;
+  }
+  return session;
+}
+
+function validatePublishPayload(body) {
+  if (!body || typeof body !== "object") {
+    throw new Error("Payload de publicación inválido.");
+  }
+  if (!body.menu || typeof body.menu !== "object") {
+    throw new Error("Falta menu en la publicación.");
+  }
+  if (!Array.isArray(body.specials)) {
+    throw new Error("Falta specials en la publicación.");
+  }
+  if (!Array.isArray(body.combos)) {
+    throw new Error("Falta combos en la publicación.");
+  }
+  if (!body.config || typeof body.config !== "object") {
+    throw new Error("Falta config en la publicación.");
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (!isOriginAllowed(String(req.headers.origin || ""))) {
+      return sendJson(res, req, 403, {
+        error: "Origin no permitido por LV_ADMIN_ALLOWED_ORIGIN.",
+      });
+    }
+
+    if (req.method === "OPTIONS") {
+      applyCors(res, req);
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+
+    if (req.method === "GET" && url.pathname === "/api/health") {
+      const cfg = config();
+      return sendJson(res, req, 200, {
+        ok: true,
+        repo: cfg.owner && cfg.repo ? `${cfg.owner}/${cfg.repo}` : null,
+        branch: cfg.branch,
+        hasPassword: Boolean(cfg.password || cfg.passwordHash),
+        hasGitHubToken: Boolean(cfg.githubToken),
+      });
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/session") {
+      const session = getSession(req);
+      return sendJson(res, req, 200, {
+        authenticated: Boolean(session),
+        user: session?.user || null,
+      });
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/session/login") {
+      requireServerConfig();
+      const body = await readJsonBody(req);
+      if (!body.password || !verifyPassword(body.password)) {
+        return sendJson(res, req, 401, {
+          error: "Contraseña incorrecta.",
+        });
+      }
+      const token = createSessionToken();
+      return sendJson(
+        res,
+        req,
+        200,
+        { ok: true, user: "Las Veraneras Admin" },
+        {
+          "Set-Cookie": makeCookie(req, token, config().sessionTtlHours * 3600),
+        },
+      );
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/session/logout") {
+      return sendJson(
+        res,
+        req,
+        200,
+        { ok: true },
+        { "Set-Cookie": clearCookie(req) },
+      );
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/publish") {
+      requireSession(req);
+      const body = await readJsonBody(req);
+      validatePublishPayload(body);
+      const ts = new Date().toISOString().slice(0, 16).replace("T", " ");
+      await putTextFile(
+        "data/menu.json",
+        JSON.stringify(body.menu, null, 2),
+        `✏️ Admin API: actualizar menú [${ts}]`,
+      );
+      await putTextFile(
+        "data/specials.json",
+        JSON.stringify(body.specials, null, 2),
+        `✏️ Admin API: actualizar especiales [${ts}]`,
+      );
+      await putTextFile(
+        "data/combos.json",
+        JSON.stringify(body.combos, null, 2),
+        `✏️ Admin API: actualizar combos [${ts}]`,
+      );
+      await putTextFile(
+        "data/config.json",
+        JSON.stringify(body.config, null, 2),
+        `✏️ Admin API: actualizar configuración [${ts}]`,
+      );
+      return sendJson(res, req, 200, {
+        ok: true,
+        publishedAt: new Date().toISOString(),
+      });
+    }
+
+    if (req.method === "GET" && url.pathname === "/api/images") {
+      requireSession(req);
+      const images = await listImages();
+      return sendJson(res, req, 200, { ok: true, images });
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/images") {
+      requireSession(req);
+      const body = await readJsonBody(req);
+      const filename = String(body.filename || "").trim();
+      if (!IMAGE_NAME_RE.test(filename) || !IMAGE_FILE_RE.test(filename)) {
+        return sendJson(res, req, 400, {
+          error: "Nombre de archivo inválido.",
+        });
+      }
+      if (!body.base64Data) {
+        return sendJson(res, req, 400, {
+          error: "Falta la imagen base64.",
+        });
+      }
+      const repoPath = `images/${filename}`;
+      await putBase64File(
+        repoPath,
+        body.base64Data,
+        `📷 Admin API: subir imagen ${filename}`,
+      );
+      return sendJson(res, req, 200, {
+        ok: true,
+        path: repoPath,
+        publicUrl: buildPublicImageUrl(filename),
+      });
+    }
+
+    if (req.method === "DELETE" && url.pathname === "/api/images") {
+      requireSession(req);
+      const body = await readJsonBody(req);
+      const repoPath = String(body.path || "").trim();
+      const sha = String(body.sha || "").trim();
+      if (!IMAGE_PATH_RE.test(repoPath)) {
+        return sendJson(res, req, 400, {
+          error: "Ruta de imagen inválida.",
+        });
+      }
+      if (!sha) {
+        return sendJson(res, req, 400, { error: "Falta el SHA." });
+      }
+      await deleteFile(
+        repoPath,
+        sha,
+        `🗑️ Admin API: eliminar imagen ${repoPath}`,
+      );
+      return sendJson(res, req, 200, { ok: true });
+    }
+
+    return notFound(res, req);
+  } catch (error) {
+    const status = error.status || 500;
+    return sendJson(res, req, status, {
+      error:
+        status === 500
+          ? error.message || "Error interno del Admin API."
+          : error.message,
+    });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Las Veraneras Admin API listening on http://localhost:${PORT}`);
+});

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -220,7 +220,13 @@ async function readJsonBody(req) {
   for await (const chunk of req) chunks.push(chunk);
   const raw = Buffer.concat(chunks).toString("utf8").trim();
   if (!raw) return {};
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    const err = new Error("Invalid JSON body.");
+    err.status = 400;
+    throw err;
+  }
 }
 
 function encodeGitHubPath(filePath) {

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -179,7 +179,7 @@ function getSession(req) {
 function isOriginAllowed(origin) {
   const cfg = config();
   if (!origin) return true;
-  if (!cfg.allowedOrigins.length) return true;
+  if (!cfg.allowedOrigins.length) return false;
   return cfg.allowedOrigins.includes(origin);
 }
 

--- a/admin-config.js
+++ b/admin-config.js
@@ -1,0 +1,1 @@
+window.LV_ADMIN_API_BASE = window.LV_ADMIN_API_BASE || "";

--- a/admin.html
+++ b/admin.html
@@ -24,6 +24,7 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.js"
       defer
     ></script>
+    <script src="admin-config.js"></script>
     <style>
       /* ── Photo Editor Modal ── */
       #photo-editor-modal {
@@ -721,187 +722,184 @@
         combos: false,
         settings: false,
       };
-      let _tok = ""; // decrypted GitHub token, kept only in memory
+      let _session = { authenticated: false, user: "" };
+      const API_BASE_STORAGE_KEY = "lv-admin-api-base";
 
-      /* ── Crypto helpers ── */
-      const STORAGE_KEY = "lv-admin-encrypted";
-      async function _deriveKey(password, salt) {
-        const km = await crypto.subtle.importKey(
-          "raw",
-          new TextEncoder().encode(password),
-          "PBKDF2",
-          false,
-          ["deriveKey"],
-        );
-        return crypto.subtle.deriveKey(
-          { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
-          km,
-          { name: "AES-GCM", length: 256 },
-          false,
-          ["encrypt", "decrypt"],
-        );
+      function normalizeApiBase(url) {
+        return String(url || "")
+          .trim()
+          .replace(/\/+$/, "");
       }
-      async function encryptToken(token, password) {
-        const salt = crypto.getRandomValues(new Uint8Array(16));
-        const iv = crypto.getRandomValues(new Uint8Array(12));
-        const key = await _deriveKey(password, salt);
-        const ct = await crypto.subtle.encrypt(
-          { name: "AES-GCM", iv },
-          key,
-          new TextEncoder().encode(token),
+
+      function getConfiguredApiBase() {
+        const stored = normalizeApiBase(
+          localStorage.getItem(API_BASE_STORAGE_KEY),
         );
-        const buf = new Uint8Array(16 + 12 + ct.byteLength);
-        buf.set(salt, 0);
-        buf.set(iv, 16);
-        buf.set(new Uint8Array(ct), 28);
-        return btoa(String.fromCharCode(...buf));
+        const configured = normalizeApiBase(window.LV_ADMIN_API_BASE || "");
+        return stored || configured || "";
       }
-      async function decryptToken(encrypted, password) {
-        const buf = Uint8Array.from(atob(encrypted), (c) => c.charCodeAt(0));
-        const key = await _deriveKey(password, buf.slice(0, 16));
-        const pt = await crypto.subtle.decrypt(
-          { name: "AES-GCM", iv: buf.slice(16, 28) },
-          key,
-          buf.slice(28),
-        );
-        return new TextDecoder().decode(pt);
+
+      function saveApiBase(url) {
+        const normalized = normalizeApiBase(url);
+        if (normalized) localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
+        else localStorage.removeItem(API_BASE_STORAGE_KEY);
+        return normalized;
+      }
+
+      function requiresExplicitApiBase() {
+        return location.hostname.endsWith(".github.io");
+      }
+
+      function getApiUrl(path) {
+        const base = getConfiguredApiBase();
+        return base ? base + path : path;
+      }
+
+      async function apiFetch(path, options = {}) {
+        const headers = new Headers(options.headers || {});
+        if (options.body && !headers.has("Content-Type")) {
+          headers.set("Content-Type", "application/json");
+        }
+        if (!headers.has("Accept")) headers.set("Accept", "application/json");
+        const res = await fetch(getApiUrl(path), {
+          ...options,
+          headers,
+          credentials: "include",
+        });
+        const text = await res.text();
+        let data = null;
+        try {
+          data = text ? JSON.parse(text) : null;
+        } catch (e) {
+          data = null;
+        }
+        if (!res.ok) {
+          throw new Error(
+            data?.error ||
+              data?.message ||
+              text ||
+              `La API respondió con ${res.status}`,
+          );
+        }
+        return data;
       }
 
       /* ── Auth UI ── */
       function renderAuthCard() {
         const card = document.getElementById("auth-card");
-        if (localStorage.getItem(STORAGE_KEY)) {
+        const apiBase = getConfiguredApiBase();
+        const requiresBase = requiresExplicitApiBase();
+        if (_session.authenticated) {
           card.innerHTML = `
       <div class="topbar"><div>
         <h2>Administrador</h2>
-        <p class="muted">Ingresa tu contraseña para publicar cambios.</p>
+        <p class="muted">La sesión segura está activa. El GitHub token vive en el servidor, no en este navegador.</p>
+      </div></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.25rem 0">
+        <p class="muted" style="margin:0">✅ Sesión activa — <strong>${esc(_session.user || "Administrador")}</strong></p>
+        <div class="admin-actions" style="margin:0">
+          <button class="btn-admin" onclick="downloadBackup()">⬇ Respaldo JSON</button>
+          <button class="btn-admin" onclick="logout()">Cerrar sesión</button>
+          <button class="btn-admin" onclick="clearApiBase()">Cambiar endpoint</button>
+        </div>
+      </div>`;
+          return;
+        }
+        card.innerHTML = `
+      <div class="topbar"><div>
+        <h2>Administrador</h2>
+        <p class="muted">Usa tu contraseña para entrar. El endpoint seguro se configura una sola vez por navegador.</p>
       </div></div>
       <label class="admin-label">Contraseña</label>
       <input id="admin-pw" type="password" class="admin-input" placeholder="••••••••" autocomplete="current-password">
+      <label class="admin-label" style="margin-top:.75rem">Admin API URL</label>
+      <input id="admin-api-base" class="admin-input" placeholder="https://tu-admin-api.example.com" value="${esc(apiBase)}" autocomplete="url">
+      <p class="muted small" style="margin-top:.25rem">${
+        requiresBase
+          ? "En GitHub Pages esta URL es obligatoria. No es secreta; solo apunta al servicio seguro."
+          : "Si el API vive en el mismo dominio, puedes dejar este campo vacío."
+      }</p>
       <div class="admin-actions">
         <button class="btn-admin-primary" onclick="loginAdmin()">Entrar</button>
         <button class="btn-admin" onclick="downloadBackup()">⬇ Respaldo JSON</button>
-        <button class="btn-admin" style="color:#e55;margin-left:auto" onclick="resetSetup()">Restablecer</button>
-      </div>`;
-          setTimeout(() => {
-            const pw = document.getElementById("admin-pw");
-            if (pw) {
-              pw.focus();
-              pw.addEventListener("keydown", (e) => {
-                if (e.key === "Enter") loginAdmin();
-              });
-            }
-          }, 50);
-        } else {
-          card.innerHTML = `
-      <div class="topbar"><div>
-        <h2>Configuración inicial</h2>
-        <p class="muted">Configura el panel una sola vez. Después solo necesitarás la contraseña.</p>
-      </div></div>
-      <label class="admin-label">Contraseña de administrador</label>
-      <input id="setup-pw1" type="password" class="admin-input" placeholder="Elige una contraseña">
-      <label class="admin-label" style="margin-top:.75rem">Confirmar contraseña</label>
-      <input id="setup-pw2" type="password" class="admin-input" placeholder="Repite la contraseña">
-      <label class="admin-label" style="margin-top:.75rem">GitHub Token <span class="muted">(solo esta vez)</span></label>
-      <input id="setup-tok" type="password" class="admin-input" placeholder="github_pat_...">
-      <p class="muted small" style="margin-top:.25rem">El token se guarda cifrado en este navegador. No se almacena en el repositorio.</p>
-      <div class="admin-actions">
-        <button class="btn-admin-primary" onclick="setupAdmin()">Configurar</button>
-      </div>`;
+        ${
+          apiBase
+            ? '<button class="btn-admin" style="margin-left:auto" onclick="clearApiBase()">Olvidar endpoint</button>'
+            : ""
         }
+      </div>`;
+        setTimeout(() => {
+          const pw = document.getElementById("admin-pw");
+          if (pw) {
+            pw.focus();
+            pw.addEventListener("keydown", (e) => {
+              if (e.key === "Enter") loginAdmin();
+            });
+          }
+        }, 50);
       }
 
-      async function setupAdmin() {
-        const pw1 = document.getElementById("setup-pw1")?.value;
-        const pw2 = document.getElementById("setup-pw2")?.value;
-        const tok = document.getElementById("setup-tok")?.value.trim();
-        if (!pw1 || pw1.length < 4) {
-          alert("La contraseña debe tener al menos 4 caracteres.");
-          return;
-        }
-        if (pw1 !== pw2) {
-          alert("Las contraseñas no coinciden.");
-          return;
-        }
-        if (!tok) {
-          alert("Ingresa el GitHub Token.");
-          return;
-        }
-        try {
-          localStorage.setItem(STORAGE_KEY, await encryptToken(tok, pw1));
-          await onLoggedIn(tok);
-        } catch (e) {
-          alert("Error al configurar: " + e.message);
-        }
+      async function clearApiBase() {
+        localStorage.removeItem(API_BASE_STORAGE_KEY);
+        if (_session.authenticated) await logout();
+        else renderAuthCard();
       }
 
       async function loginAdmin() {
         const pw = document.getElementById("admin-pw")?.value;
-        if (!pw) return;
-        const encrypted = localStorage.getItem(STORAGE_KEY);
-        if (!encrypted) {
-          renderAuthCard();
+        const apiInput = document.getElementById("admin-api-base")?.value;
+        if (!pw) {
+          alert("Ingresa la contraseña.");
+          return;
+        }
+        saveApiBase(apiInput);
+        const apiBase = getConfiguredApiBase();
+        if (requiresExplicitApiBase() && !apiBase) {
+          alert("Configura la URL del Admin API antes de entrar.");
           return;
         }
         document.getElementById("status").textContent = "Verificando…";
         try {
-          await onLoggedIn(await decryptToken(encrypted, pw));
-        } catch (e) {
-          document.getElementById("status").textContent =
-            "✗ Contraseña incorrecta";
-          document.getElementById("status").className = "status-badge error";
-          alert("Contraseña incorrecta.");
-        }
-      }
-
-      async function onLoggedIn(tok) {
-        const status = document.getElementById("status");
-        try {
-          const res = await fetch("https://api.github.com/user", {
-            headers: {
-              Authorization: "token " + tok,
-              Accept: "application/vnd.github.v3+json",
-            },
+          const data = await apiFetch("/api/session/login", {
+            method: "POST",
+            body: JSON.stringify({ password: pw }),
           });
-          if (!res.ok) throw new Error("Token inválido");
-          const user = await res.json();
-          _tok = tok;
-          status.textContent = "✓ " + user.login;
-          status.className = "status-badge connected";
-          document.getElementById("publish-btn").disabled = false;
-          document.getElementById("auth-card").innerHTML = `
-      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;padding:.25rem 0">
-        <p class="muted" style="margin:0">✅ Sesión activa — <strong>${esc(user.login)}</strong></p>
-        <div class="admin-actions" style="margin:0">
-          <button class="btn-admin" onclick="downloadBackup()">⬇ Respaldo JSON</button>
-          <button class="btn-admin" onclick="logout()">Cerrar sesión</button>
-        </div>
-      </div>`;
-          await loadAll();
+          await onLoggedIn(data?.user || "Administrador");
         } catch (e) {
-          status.textContent = "✗ " + e.message;
-          status.className = "status-badge error";
-          _tok = "";
+          document.getElementById("status").textContent = "✗ " + e.message;
+          document.getElementById("status").className = "status-badge error";
+          alert("No se pudo iniciar sesión: " + e.message);
         }
       }
 
-      function logout() {
-        _tok = "";
+      async function restoreSession() {
+        if (requiresExplicitApiBase() && !getConfiguredApiBase()) return;
+        try {
+          const data = await apiFetch("/api/session");
+          if (data?.authenticated) {
+            await onLoggedIn(data.user || "Administrador", false);
+          }
+        } catch (e) {}
+      }
+
+      async function onLoggedIn(user, shouldLoad = true) {
+        const status = document.getElementById("status");
+        _session = { authenticated: true, user };
+        status.textContent = "✓ " + user;
+        status.className = "status-badge connected";
+        document.getElementById("publish-btn").disabled = false;
+        renderAuthCard();
+        if (shouldLoad) await loadAll();
+      }
+
+      async function logout() {
+        try {
+          await apiFetch("/api/session/logout", { method: "POST" });
+        } catch (e) {}
+        _session = { authenticated: false, user: "" };
         document.getElementById("status").textContent = "Sin conectar";
         document.getElementById("status").className = "status-badge";
         document.getElementById("publish-btn").disabled = true;
-        renderAuthCard();
-      }
-
-      function resetSetup() {
-        if (
-          !confirm(
-            "¿Eliminar la configuración guardada? Necesitarás ingresar el GitHub Token de nuevo.",
-          )
-        )
-          return;
-        localStorage.removeItem(STORAGE_KEY);
-        _tok = "";
         renderAuthCard();
       }
 
@@ -934,9 +932,6 @@
           .replace(/'/g, "&#39;");
       }
 
-      function getToken() {
-        return _tok;
-      }
       function markDirty(tab) {
         dirty[tab] = true;
         const btn = document.getElementById("tab-" + tab);
@@ -1546,75 +1541,11 @@
         }
       }
 
-      /* ── GitHub file helpers ── */
-      async function getFileSHA(path) {
-        const token = getToken();
-        const [owner, repo] = getOwnerRepo();
-        try {
-          const res = await fetch(
-            `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
-            {
-              headers: {
-                Authorization: "token " + token,
-                Accept: "application/vnd.github.v3+json",
-              },
-            },
-          );
-          if (res.ok) {
-            const d = await res.json();
-            return d.sha;
-          }
-        } catch (e) {}
-        return null;
-      }
-
-      async function putFile(path, content, message) {
-        const token = getToken();
-        const [owner, repo] = getOwnerRepo();
-        const sha = await getFileSHA(path);
-        const body = {
-          message,
-          content: btoa(unescape(encodeURIComponent(content))),
-        };
-        if (sha) body.sha = sha;
-        const res = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
-          {
-            method: "PUT",
-            headers: {
-              Authorization: "token " + token,
-              Accept: "application/vnd.github.v3+json",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body),
-          },
-        );
-        if (!res.ok) {
-          const e = await res.json();
-          throw new Error(e.message || "Error guardando " + path);
-        }
-        return res.json();
-      }
-
-      function getOwnerRepo() {
-        // GitHub Pages: username.github.io/reponame/...
-        const m = location.hostname.match(/^([^.]+)\.github\.io$/);
-        if (m) {
-          const owner = m[1];
-          const repo =
-            location.pathname.split("/").filter(Boolean)[0] ||
-            "las-veraneras-menu";
-          return [owner, repo];
-        }
-        // Fallback for local dev or custom domains
-        return ["sandgraal", "las-veraneras-menu"];
-      }
-
       /* ── Publish All ── */
       async function publishAll() {
         const btn = document.getElementById("publish-btn");
         const status = document.getElementById("status");
-        if (!getToken()) {
+        if (!_session.authenticated) {
           alert("Inicia sesión primero.");
           return;
         }
@@ -1625,27 +1556,15 @@
         try {
           const cfgToSave = readSettings();
           combosData = readCombos();
-          const ts = new Date().toISOString().slice(0, 16).replace("T", " ");
-          await putFile(
-            "data/menu.json",
-            JSON.stringify(menuData, null, 2),
-            `✏️ Admin: actualizar menú [${ts}]`,
-          );
-          await putFile(
-            "data/specials.json",
-            JSON.stringify(specialsData, null, 2),
-            `✏️ Admin: actualizar especiales [${ts}]`,
-          );
-          await putFile(
-            "data/combos.json",
-            JSON.stringify(combosData, null, 2),
-            `✏️ Admin: actualizar combos [${ts}]`,
-          );
-          await putFile(
-            "data/config.json",
-            JSON.stringify(cfgToSave, null, 2),
-            `✏️ Admin: actualizar configuración [${ts}]`,
-          );
+          await apiFetch("/api/publish", {
+            method: "POST",
+            body: JSON.stringify({
+              menu: menuData,
+              specials: specialsData,
+              combos: combosData,
+              config: cfgToSave,
+            }),
+          });
           localStorage.setItem("lv-last-saved", new Date().toISOString());
           status.textContent = "✓ Publicado";
           status.className = "status-badge connected";
@@ -1699,34 +1618,14 @@
       }
 
       async function uploadImageToGitHub(base64Data, filename) {
-        const token = getToken();
-        if (!token)
+        if (!_session.authenticated) {
           throw new Error("No hay sesión activa. Inicia sesión primero.");
-        const [owner, repo] = getOwnerRepo();
-        const path = "images/" + filename;
-        const sha = await getFileSHA(path);
-        const body = {
-          message: "\u{1F4F7} Admin: subir imagen " + filename,
-          content: base64Data,
-        };
-        if (sha) body.sha = sha;
-        const res = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
-          {
-            method: "PUT",
-            headers: {
-              Authorization: "token " + token,
-              Accept: "application/vnd.github.v3+json",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body),
-          },
-        );
-        if (!res.ok) {
-          const e = await res.json();
-          throw new Error(e.message || "Error al subir imagen");
         }
-        return path; // 'images/filename.webp'
+        const data = await apiFetch("/api/images", {
+          method: "POST",
+          body: JSON.stringify({ base64Data, filename }),
+        });
+        return data.path;
       }
 
       /* ── Photo Editor State & Logic (Phase 2) ── */
@@ -1961,35 +1860,15 @@
       async function loadImageLibrary() {
         const grid = document.getElementById("photo-library-grid");
         if (!grid) return;
-        const token = getToken();
-        if (!token) {
+        if (!_session.authenticated) {
           grid.innerHTML =
             '<p class="muted">Inicia sesión para ver las fotos.</p>';
           return;
         }
         grid.innerHTML = '<p class="muted">Cargando\u2026</p>';
-        const [owner, repo] = getOwnerRepo();
         try {
-          const res = await fetch(
-            `https://api.github.com/repos/${owner}/${repo}/contents/images`,
-            {
-              headers: {
-                Authorization: "token " + token,
-                Accept: "application/vnd.github.v3+json",
-              },
-            },
-          );
-          if (!res.ok) {
-            grid.innerHTML =
-              '<p class="muted">No se pudo cargar la biblioteca.</p>';
-            return;
-          }
-          const files = await res.json();
-          const images = Array.isArray(files)
-            ? files.filter((f) =>
-                /\.(jpe?g|png|webp|gif|svg|heic)$/i.test(f.name),
-              )
-            : [];
+          const data = await apiFetch("/api/images");
+          const images = Array.isArray(data?.images) ? data.images : [];
           if (!images.length) {
             grid.innerHTML =
               '<p class="muted">No hay fotos aún. Usa el botón 📷 junto a cualquier plato o especial para subir fotos.</p>';
@@ -1998,10 +1877,10 @@
           grid.innerHTML = images
             .map((f) => {
               const kb = Math.round(f.size / 1024);
-              const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/images/${encodeURIComponent(f.name)}`;
+              const thumbUrl = `${f.path}?v=${encodeURIComponent(f.sha.slice(0, 8))}`;
               const cardId = "lib-" + f.sha.slice(0, 8);
               return `<div class="photo-lib-card" id="${esc(cardId)}">
-        <img src="${esc(rawUrl)}" alt="${esc(f.name)}" loading="lazy">
+        <img src="${esc(thumbUrl)}" alt="${esc(f.name)}" loading="lazy">
         <div class="photo-lib-card-body">
           <div class="photo-lib-filename" title="${esc(f.name)}">${esc(f.name)}</div>
           <div class="photo-lib-filename">${kb} KB</div>
@@ -2038,28 +1917,11 @@
           )
         )
           return;
-        const token = getToken();
-        const [owner, repo] = getOwnerRepo();
         try {
-          const res = await fetch(
-            `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
-            {
-              method: "DELETE",
-              headers: {
-                Authorization: "token " + token,
-                Accept: "application/vnd.github.v3+json",
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                message: "\u{1F5D1}\uFE0F Admin: eliminar imagen " + path,
-                sha,
-              }),
-            },
-          );
-          if (!res.ok) {
-            const e = await res.json();
-            throw new Error(e.message || "Error al eliminar");
-          }
+          await apiFetch("/api/images", {
+            method: "DELETE",
+            body: JSON.stringify({ path, sha }),
+          });
           document.getElementById(cardId)?.remove();
         } catch (e) {
           alert("Error al eliminar: " + e.message);
@@ -2071,6 +1933,7 @@
         renderAuthCard();
         peSetupDragDrop();
         await loadAll(); // read-only pre-load so data shows in preview tab
+        await restoreSession();
       })();
     </script>
   </body>

--- a/admin.html
+++ b/admin.html
@@ -841,9 +841,13 @@
       }
 
       async function clearApiBase() {
-        localStorage.removeItem(API_BASE_STORAGE_KEY);
-        if (_session.authenticated) await logout();
-        else renderAuthCard();
+        if (_session.authenticated) {
+          await logout();
+          localStorage.removeItem(API_BASE_STORAGE_KEY);
+        } else {
+          localStorage.removeItem(API_BASE_STORAGE_KEY);
+          renderAuthCard();
+        }
       }
 
       async function loginAdmin() {

--- a/tools/validate-menu.js
+++ b/tools/validate-menu.js
@@ -1,21 +1,35 @@
 #!/usr/bin/env node
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const ROOT = path.resolve(__dirname, '..');
-const LANGS = ['es', 'en', 'fr'];
-const REQUIRED_CONFIG = ['restaurantName', 'tagline', 'taglineEn', 'taglineFr', 'address', 'whatsappNumber', 'heroImage'];
-const BEST_FOR = new Set(['quick-lunch', 'sharing', 'french-specialty', 'local-favorite', 'dessert']);
-const DIETARY = new Set(['vegetarian']);
+const ROOT = path.resolve(__dirname, "..");
+const LANGS = ["es", "en", "fr"];
+const REQUIRED_CONFIG = [
+  "restaurantName",
+  "tagline",
+  "taglineEn",
+  "taglineFr",
+  "address",
+  "whatsappNumber",
+  "heroImage",
+];
+const BEST_FOR = new Set([
+  "quick-lunch",
+  "sharing",
+  "french-specialty",
+  "local-favorite",
+  "dessert",
+]);
+const DIETARY = new Set(["vegetarian"]);
 
 const errors = [];
 const warnings = [];
 
 function readJson(file) {
   try {
-    return JSON.parse(fs.readFileSync(path.join(ROOT, file), 'utf8'));
+    return JSON.parse(fs.readFileSync(path.join(ROOT, file), "utf8"));
   } catch (err) {
     errors.push(`${file}: ${err.message}`);
     return null;
@@ -26,7 +40,7 @@ function isUrl(value) {
   if (!value) return true;
   try {
     const u = new URL(value);
-    return u.protocol === 'http:' || u.protocol === 'https:';
+    return u.protocol === "http:" || u.protocol === "https:";
   } catch {
     return false;
   }
@@ -39,90 +53,113 @@ function isImageRef(value) {
 }
 
 function requireText(obj, field, where) {
-  if (!obj || typeof obj[field] !== 'string' || !obj[field].trim()) {
+  if (!obj || typeof obj[field] !== "string" || !obj[field].trim()) {
     errors.push(`${where}: missing ${field}`);
   }
 }
 
 function requireLang(obj, field, where) {
-  LANGS.forEach(lang => {
-    if (!obj?.[field]?.[lang] || typeof obj[field][lang] !== 'string') {
+  LANGS.forEach((lang) => {
+    if (!obj?.[field]?.[lang] || typeof obj[field][lang] !== "string") {
       errors.push(`${where}: missing ${field}.${lang}`);
     }
   });
 }
 
-const menu = readJson('data/menu.json');
-const combos = readJson('data/combos.json') || [];
-const config = readJson('data/config.json');
-readJson('data/specials.json');
+const menu = readJson("data/menu.json");
+const combos = readJson("data/combos.json") || [];
+const config = readJson("data/config.json");
+readJson("data/specials.json");
 
 if (config) {
-  REQUIRED_CONFIG.forEach(field => requireText(config, field, 'data/config.json'));
-  if (!isImageRef(config.heroImage)) errors.push('data/config.json: heroImage must be http/https URL or images/... path');
-  if (config.storyImage && !isImageRef(config.storyImage)) errors.push('data/config.json: storyImage must be http/https URL or images/... path');
-  if (!config.brandStory || LANGS.some(lang => !config.brandStory[lang])) {
-    errors.push('data/config.json: brandStory must include es, en, fr');
+  REQUIRED_CONFIG.forEach((field) =>
+    requireText(config, field, "data/config.json"),
+  );
+  if (!isImageRef(config.heroImage))
+    errors.push(
+      "data/config.json: heroImage must be http/https URL or images/... path",
+    );
+  if (config.storyImage && !isImageRef(config.storyImage))
+    errors.push(
+      "data/config.json: storyImage must be http/https URL or images/... path",
+    );
+  if (!config.brandStory || LANGS.some((lang) => !config.brandStory[lang])) {
+    errors.push("data/config.json: brandStory must include es, en, fr");
   }
 }
 
 const ids = new Set();
 if (!menu?.categories?.length) {
-  errors.push('data/menu.json: categories must be a non-empty array');
+  errors.push("data/menu.json: categories must be a non-empty array");
 } else {
   menu.categories.forEach((cat, ci) => {
     const cwhere = `data/menu.json category[${ci}]`;
-    requireText(cat, 'id', cwhere);
-    requireLang(cat, 'name', cwhere);
-    if (!Array.isArray(cat.items) || !cat.items.length) errors.push(`${cwhere}: items must be non-empty`);
+    requireText(cat, "id", cwhere);
+    requireLang(cat, "name", cwhere);
+    if (!Array.isArray(cat.items) || !cat.items.length)
+      errors.push(`${cwhere}: items must be non-empty`);
     (cat.items || []).forEach((item, ii) => {
-      const where = `${cwhere} item[${ii}] ${item.id || '<missing-id>'}`;
-      requireText(item, 'id', where);
+      const where = `${cwhere} item[${ii}] ${item.id || "<missing-id>"}`;
+      requireText(item, "id", where);
       if (ids.has(item.id)) errors.push(`${where}: duplicate item id`);
       ids.add(item.id);
-      requireLang(item, 'name', where);
-      requireLang(item, 'description', where);
-      requireLang(item, 'story', where);
-      if (!/^\d+$/.test(String(item.price || ''))) errors.push(`${where}: price must be a whole number string`);
-      if (item.image && !isImageRef(item.image)) errors.push(`${where}: image must be http/https URL or images/... path`);
-      if (item.photoAlt) requireLang(item, 'photoAlt', where);
-      ['allergens', 'bestFor', 'dietaryTags', 'addons', 'pairings'].forEach(field => {
-        if (!Array.isArray(item[field])) errors.push(`${where}: ${field} must be an array`);
+      requireLang(item, "name", where);
+      requireLang(item, "description", where);
+      requireLang(item, "story", where);
+      if (!/^\d+$/.test(String(item.price || "")))
+        errors.push(`${where}: price must be a whole number string`);
+      if (item.image && !isImageRef(item.image))
+        errors.push(
+          `${where}: image must be http/https URL or images/... path`,
+        );
+      if (item.photoAlt) requireLang(item, "photoAlt", where);
+      ["allergens", "bestFor", "dietaryTags", "addons", "pairings"].forEach(
+        (field) => {
+          if (!Array.isArray(item[field]))
+            errors.push(`${where}: ${field} must be an array`);
+        },
+      );
+      (item.bestFor || []).forEach((tag) => {
+        if (!BEST_FOR.has(tag))
+          warnings.push(`${where}: unknown bestFor tag "${tag}"`);
       });
-      (item.bestFor || []).forEach(tag => {
-        if (!BEST_FOR.has(tag)) warnings.push(`${where}: unknown bestFor tag "${tag}"`);
-      });
-      (item.dietaryTags || []).forEach(tag => {
-        if (!DIETARY.has(tag)) warnings.push(`${where}: unknown dietary tag "${tag}"`);
+      (item.dietaryTags || []).forEach((tag) => {
+        if (!DIETARY.has(tag))
+          warnings.push(`${where}: unknown dietary tag "${tag}"`);
       });
     });
   });
 }
 
 if (!Array.isArray(combos)) {
-  errors.push('data/combos.json: must be an array');
+  errors.push("data/combos.json: must be an array");
 } else {
   const comboIds = new Set();
   combos.forEach((combo, idx) => {
-    const where = `data/combos.json combo[${idx}] ${combo.id || '<missing-id>'}`;
-    requireText(combo, 'id', where);
+    const where = `data/combos.json combo[${idx}] ${combo.id || "<missing-id>"}`;
+    requireText(combo, "id", where);
     if (comboIds.has(combo.id)) errors.push(`${where}: duplicate combo id`);
     comboIds.add(combo.id);
-    requireLang(combo, 'name', where);
-    requireLang(combo, 'description', where);
-    requireLang(combo, 'tag', where);
-    if (!Array.isArray(combo.items) || !combo.items.length) errors.push(`${where}: items must be non-empty`);
-    (combo.items || []).forEach(id => {
-      if (!ids.has(id)) errors.push(`${where}: references missing menu item "${id}"`);
+    requireLang(combo, "name", where);
+    requireLang(combo, "description", where);
+    requireLang(combo, "tag", where);
+    if (!Array.isArray(combo.items) || !combo.items.length)
+      errors.push(`${where}: items must be non-empty`);
+    (combo.items || []).forEach((id) => {
+      if (!ids.has(id))
+        errors.push(`${where}: references missing menu item "${id}"`);
     });
-    if (!/^\d+$/.test(String(combo.price || ''))) errors.push(`${where}: price must be a whole number string`);
+    if (!/^\d+$/.test(String(combo.price || "")))
+      errors.push(`${where}: price must be a whole number string`);
   });
 }
 
-warnings.forEach(w => console.warn(`warning: ${w}`));
+warnings.forEach((w) => console.warn(`warning: ${w}`));
 if (errors.length) {
-  console.error(errors.map(e => `error: ${e}`).join('\n'));
+  console.error(errors.map((e) => `error: ${e}`).join("\n"));
   process.exit(1);
 }
 
-console.log(`validate-menu: ok (${ids.size} menu items, ${combos.length} combos)`);
+console.log(
+  `validate-menu: ok (${ids.size} menu items, ${combos.length} combos)`,
+);


### PR DESCRIPTION
## What this PR does

Removes the AES-GCM browser-side GitHub token encryption and replaces it with a proper server-side admin backend. The GitHub write token now lives exclusively on the server — never in the browser.

## Changes

### `admin-api/` — new Node.js service (zero dependencies, stdlib only)
- Password-only login with `HttpOnly` session cookie (HMAC-SHA256 signed, configurable TTL)
- Scrypt password hashing utility (`hash-password.js`) for production use
- GitHub Contents API calls (publish, image upload, image delete, image list) done server-side
- CORS enforced via `LV_ADMIN_ALLOWED_ORIGIN`
- Input validation on all routes (path allowlist, base64 check, filename regex)

### `admin.html`
- Removed: AES-GCM key derivation, `encryptToken`/`decryptToken`, `setupAdmin`, `resetSetup`, `getToken`, `getOwnerRepo`, `getFileSHA`, `putFile`
- Added: `apiFetch` wrapper (sends cookies, parses JSON errors), `restoreSession` (rehydrates auth on page load), `saveApiBase`/`getConfiguredApiBase` for one-time endpoint config
- Auth flow: enter password → POST `/api/session/login` → server sets cookie → all subsequent calls are session-authenticated
- Added "Admin API URL" field on login screen (required on GitHub Pages, optional on same-origin deploys)

### `admin-config.js` (new)
Sets `window.LV_ADMIN_API_BASE` for deployed environments without touching `admin.html`.

### Other
- `.gitignore` — excludes `node_modules/`, `.env`, `.DS_Store`
- `README.md` — documents the admin API setup and local dev workflow
- `tools/validate-menu.js` — resolved 3-way merge conflict; kept strict extension-aware `isImageRef` + consistent Prettier formatting

## Security improvements
- GitHub PAT never touches the browser
- Session cookie is `HttpOnly; SameSite=Lax` (or `SameSite=None; Secure` cross-origin)
- Timing-safe password comparison (`crypto.timingSafeEqual`)
- Scrypt hashing available for production passwords
- Path traversal prevented by strict regex on all file paths

## Deployment notes
`admin-api/` is a standalone Node service. Deploy to Railway, Render, Fly.io, or any Node host. Set `LV_ADMIN_ALLOWED_ORIGIN` to the exact GitHub Pages origin. See `admin-api/README.md` for full env var reference.
