### PR TITLE
Fix photo upload failing on large/phone photos

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2586,7 +2586,6 @@
         const url = URL.createObjectURL(file);
         const img = document.getElementById("pe-img");
         img.onload = () => {
-          URL.revokeObjectURL(url);
           document.getElementById("pe-dropzone").style.display = "none";
           document.getElementById("pe-editor").style.display = "";
           document.getElementById("pe-brightness").value = 0;
@@ -2603,7 +2602,30 @@
             responsive: true,
           });
         };
-        img.src = url;
+        // Downscale very large photos before handing them to Cropper. Phone
+        // cameras produce images whose pixel area exceeds the mobile browser
+        // canvas limit, which makes getCroppedCanvas() return null on upload.
+        const loader = new Image();
+        loader.onload = () => {
+          URL.revokeObjectURL(url);
+          const MAX_SIDE = 2000;
+          const scale = Math.min(
+            1,
+            MAX_SIDE / Math.max(loader.naturalWidth, loader.naturalHeight),
+          );
+          const w = Math.max(1, Math.round(loader.naturalWidth * scale));
+          const h = Math.max(1, Math.round(loader.naturalHeight * scale));
+          const tmp = document.createElement("canvas");
+          tmp.width = w;
+          tmp.height = h;
+          tmp.getContext("2d").drawImage(loader, 0, 0, w, h);
+          img.src = tmp.toDataURL("image/jpeg", 0.92);
+        };
+        loader.onerror = () => {
+          URL.revokeObjectURL(url);
+          alert("No se pudo cargar la imagen. Intenta con otra foto.");
+        };
+        loader.src = url;
       }
 
       function peFlipH() {
@@ -2643,6 +2665,11 @@
             maxHeight: maxDim,
             imageSmoothingQuality: "high",
           });
+          if (!cropped) {
+            throw new Error(
+              "No se pudo procesar la imagen. Intenta con una foto más pequeña.",
+            );
+          }
           const finalCanvas = document.createElement("canvas");
           finalCanvas.width = cropped.width;
           finalCanvas.height = cropped.height;


### PR DESCRIPTION
## Summary
- Customers got **"Error al subir: Cannot read properties of null (reading 'width')"** when uploading photos from their phones.
- Cause: the full-resolution image was fed straight into Cropper.js. High-megapixel phone photos exceed the mobile browser's max canvas area, so `getCroppedCanvas()` returned `null` and `cropped.width` threw.
- Fix: downscale the source to a max 2000px side (via a temp canvas) before initializing Cropper, keeping it well under device canvas limits. Added a null-guard on the cropped canvas with a clear message.

## Test plan
- [x] Inline JS parses
- [x] Drove the editor in a browser with a synthetic 5000×3500 image: source downscaled to 2000×1400, `getCroppedCanvas()` returns a valid 1200×840 canvas (previously null), editor renders and crop UI works
- [ ] Customer uploads a real phone photo after deploy and confirms success

🤖 Generated with [Claude Code](https://claude.com/claude-code)