### PR TITLE
Pilot quick wins: auto-detect language, quick add-dish, longer session

### DIFF
--- a/admin-api/.env.example
+++ b/admin-api/.env.example
@@ -2,8 +2,12 @@ LV_ADMIN_PASSWORD=change-me
 # Or generate a hash with: npm run hash:password -- Pierre
 # LV_ADMIN_PASSWORD_HASH=scrypt$...
 LV_ADMIN_SESSION_SECRET=replace-with-a-long-random-secret
-LV_ADMIN_SESSION_TTL_HOURS=12
-LV_ADMIN_ALLOWED_ORIGIN=https://sandgraal.github.io/las-veraneras-menu
+# Session lifetime in hours. 720 = 30 days; with rolling refresh the owner
+# stays logged in as long as they open the panel at least once per period.
+LV_ADMIN_SESSION_TTL_HOURS=720
+# Must be the bare browser Origin (scheme + host, NO path) — the browser never
+# sends a path in the Origin header, so a path here breaks CORS.
+LV_ADMIN_ALLOWED_ORIGIN=https://sandgraal.github.io
 LV_GITHUB_TOKEN=github_pat_replace_me
 LV_GITHUB_OWNER=sandgraal
 LV_GITHUB_REPO=las-veraneras-menu

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -39,7 +39,7 @@ function config() {
     password: process.env.LV_ADMIN_PASSWORD || "",
     passwordHash: process.env.LV_ADMIN_PASSWORD_HASH || "",
     sessionSecret: process.env.LV_ADMIN_SESSION_SECRET || "",
-    sessionTtlHours: Number(process.env.LV_ADMIN_SESSION_TTL_HOURS || 12),
+    sessionTtlHours: Number(process.env.LV_ADMIN_SESSION_TTL_HOURS || 720),
     allowedOrigins: String(process.env.LV_ADMIN_ALLOWED_ORIGIN || "")
       .split(",")
       .map((s) => s.trim())
@@ -419,10 +419,27 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === "GET" && url.pathname === "/api/session") {
       const session = getSession(req);
-      return sendJson(res, req, 200, {
-        authenticated: Boolean(session),
-        user: session?.user || null,
-      });
+      // Rolling session: each time the admin loads, slide the expiry forward so
+      // an active owner stays logged in instead of re-entering the password.
+      const extra = session
+        ? {
+            "Set-Cookie": makeCookie(
+              req,
+              createSessionToken(),
+              config().sessionTtlHours * 3600,
+            ),
+          }
+        : undefined;
+      return sendJson(
+        res,
+        req,
+        200,
+        {
+          authenticated: Boolean(session),
+          user: session?.user || null,
+        },
+        extra,
+      );
     }
 
     if (req.method === "POST" && url.pathname === "/api/session/login") {

--- a/admin.html
+++ b/admin.html
@@ -1405,6 +1405,7 @@
               <span style="font-size:1.3rem">${esc(cat.emoji || "\ud83c\udf74")}</span>
               <span class="cat-name">${esc(cat.name?.es || "Categor\u00eda")}</span>
               <span class="muted small">${(cat.items || []).length} platos</span>
+              <button class="btn-admin-primary" style="padding:.2rem .6rem;font-size:.8rem;white-space:nowrap" onclick="event.stopPropagation();addItem(${ci})" title="Agregar plato a esta categor\u00eda">\uff0b Plato</button>
               <button class="cat-toggle" id="cat-toggle-${ci}">\u25bc</button>
               <button class="btn-admin" style="padding:.15rem .45rem;font-size:.75rem" onclick="event.stopPropagation();moveCategory(${ci},-1)" title="Subir categor\u00eda" ${ci === 0 ? "disabled" : ""}>\u25b2</button>
               <button class="btn-admin" style="padding:.15rem .45rem;font-size:.75rem" onclick="event.stopPropagation();moveCategory(${ci},1)" title="Bajar categor\u00eda" ${ci === (menuData.categories || []).length - 1 ? "disabled" : ""}>\u25bc</button>
@@ -1675,6 +1676,18 @@
         // Re-open category
         const body = document.getElementById("cat-body-" + ci);
         if (body && !body.classList.contains("open")) toggleCat(ci);
+        // Scroll to and focus the new dish so the owner can edit it right away
+        const ii = menuData.categories[ci].items.length - 1;
+        setTimeout(() => {
+          const block = document.getElementById("item-block-" + ci + "-" + ii);
+          if (!block) return;
+          block.scrollIntoView({ behavior: "smooth", block: "center" });
+          const firstInput = block.querySelector("input");
+          if (firstInput) {
+            firstInput.focus();
+            firstInput.select();
+          }
+        }, 80);
       }
 
       function removeItem(ci, ii) {

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
 'use strict';
 
 /* ── State ─────────────────────────────────────────────────────────── */
-let lang = localStorage.getItem('lv-lang') || 'es';
+let lang = 'es'; // real initial value chosen in init() via detectInitialLang()
 let selected = 'all';
 let menuData = { categories: [] };
 let comboData = [];
@@ -415,6 +415,29 @@ function handleWaClick(e) {
 }
 
 /* ── Language ───────────────────────────────────────────────────────── */
+// Choose the initial language: explicit ?lang= link > saved choice >
+// visitor's browser language > Spanish. Called once at init after config loads.
+function detectInitialLang() {
+  const enabled = siteConfig.availableLanguages || ['es', 'en', 'fr'];
+  const norm = c => String(c || '').trim().slice(0, 2).toLowerCase();
+  // 1. Explicit ?lang= (shareable per-language links / hreflang targets)
+  const qp = norm(new URLSearchParams(location.search).get('lang'));
+  if (qp && enabled.includes(qp)) return qp;
+  // 2. Previously chosen language (manual switcher persists this)
+  const saved = norm(localStorage.getItem('lv-lang'));
+  if (saved && enabled.includes(saved)) return saved;
+  // 3. Visitor's browser languages, in preference order
+  const navLangs = (navigator.languages && navigator.languages.length)
+    ? navigator.languages
+    : [navigator.language || navigator.userLanguage || ''];
+  for (const l of navLangs) {
+    const base = norm(l);
+    if (enabled.includes(base)) return base;
+  }
+  // 4. Fallback to Spanish (primary local language)
+  return 'es';
+}
+
 function setLang(l) {
   if (!languageEnabled(l)) l = 'es';
   lang = l;
@@ -930,7 +953,7 @@ async function init() {
   }
 
   await loadData();
-  setLang(lang); // apply initial language
+  setLang(detectInitialLang()); // auto-detect & apply initial language
   renderSpecials();
   renderAll();
 


### PR DESCRIPTION
Phase A of the pilot-feedback improvement program (Pierre's feedback).

## Changes
- **Auto-detect language (public)** — `app.js` now picks the language from `?lang=` → saved choice → `navigator.languages` → `es`, instead of always defaulting to Spanish. Manual switcher still overrides and persists. Verified: `en-US` → English, `?lang=fr` → French.
- **Quick add-dish (admin)** — a "＋ Plato" button in each category header adds a dish without scrolling; the new dish is scrolled into view and its first field focused. Verified in browser.
- **Longer admin session** — default TTL 30 days + rolling refresh on `/api/session` (`server.js`) so the owner stays logged in. ⚠️ If Railway has `LV_ADMIN_SESSION_TTL_HOURS=12` set, it will override this — remove it or set it to 720.
- Corrected `.env.example` allowed-origin note (must be bare origin, no path).

## Test plan
- [x] app.js / admin.html / server.js syntax checks
- [x] Public: en-US auto-opens English; `?lang=fr` opens French; switcher overrides
- [x] Admin: "＋ Plato" adds dish + focuses new item
- [ ] After deploy: confirm live on Pages; confirm Railway redeploys the session change

🤖 Generated with [Claude Code](https://claude.com/claude-code)