### PR TITLE
Phase B: Auto-translate menu text via Claude API

### DIFF
--- a/admin-api/.env.example
+++ b/admin-api/.env.example
@@ -13,3 +13,8 @@ LV_GITHUB_OWNER=sandgraal
 LV_GITHUB_REPO=las-veraneras-menu
 LV_GITHUB_BRANCH=main
 LV_PUBLIC_SITE_BASE=https://sandgraal.github.io/las-veraneras-menu
+# Auto-translation (admin "✨ Traducir" buttons). Get a key at console.anthropic.com.
+# If unset, the translate endpoint returns a clear "not configured" error and
+# nothing else breaks. Model defaults to the cheap claude-haiku-4-5.
+LV_ANTHROPIC_API_KEY=sk-ant-replace_me
+# LV_TRANSLATE_MODEL=claude-haiku-4-5

--- a/admin-api/server.js
+++ b/admin-api/server.js
@@ -44,6 +44,8 @@ function config() {
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean),
+    anthropicApiKey: process.env.LV_ANTHROPIC_API_KEY || "",
+    translateModel: process.env.LV_TRANSLATE_MODEL || "claude-haiku-4-5",
     githubToken: process.env.LV_GITHUB_TOKEN || "",
     owner: process.env.LV_GITHUB_OWNER || "",
     repo: process.env.LV_GITHUB_REPO || "",
@@ -385,6 +387,137 @@ function validatePublishPayload(body) {
   }
 }
 
+const TRANSLATE_LANGS = {
+  es: "Spanish",
+  en: "English",
+  fr: "French",
+};
+const TRANSLATE_MAX_CHARS = 4000;
+
+function httpError(message, status) {
+  return Object.assign(new Error(message), { status });
+}
+
+// Translate a set of menu text fields from one language into one or more
+// targets using the Claude API. Input:
+//   { source: "es", targets: ["en","fr"], fields: { name, description, story } }
+// Output (per target): { en: { name, description, story }, fr: {...} }
+async function translateFields(body) {
+  const cfg = config();
+  if (!cfg.anthropicApiKey) {
+    throw httpError(
+      "La traducción automática no está configurada (falta LV_ANTHROPIC_API_KEY).",
+      503,
+    );
+  }
+  const source = String(body?.source || "").slice(0, 2).toLowerCase();
+  if (!TRANSLATE_LANGS[source]) {
+    throw httpError("Idioma de origen inválido.", 400);
+  }
+  const targets = Array.isArray(body?.targets)
+    ? [...new Set(body.targets.map((t) => String(t || "").slice(0, 2).toLowerCase()))]
+        .filter((t) => TRANSLATE_LANGS[t] && t !== source)
+    : [];
+  if (!targets.length) {
+    throw httpError("No hay idiomas de destino válidos.", 400);
+  }
+  // Keep only non-empty string fields, capped in length.
+  const fields = {};
+  for (const [k, v] of Object.entries(body?.fields || {})) {
+    if (typeof v === "string" && v.trim()) {
+      fields[k] = v.slice(0, TRANSLATE_MAX_CHARS);
+    }
+  }
+  const fieldNames = Object.keys(fields);
+  if (!fieldNames.length) {
+    throw httpError("No hay texto para traducir.", 400);
+  }
+
+  // Build a strict JSON schema so the model returns exactly the shape we expect.
+  const fieldProps = {};
+  for (const f of fieldNames) fieldProps[f] = { type: "string" };
+  const langSchema = {
+    type: "object",
+    additionalProperties: false,
+    properties: fieldProps,
+    required: fieldNames,
+  };
+  const schemaProps = {};
+  for (const t of targets) schemaProps[t] = langSchema;
+  const schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: schemaProps,
+    required: targets,
+  };
+
+  const system =
+    "You are a professional menu translator for Las Veraneras, a French-Costa Rican " +
+    "bistro in Tucurrique, Costa Rica. Translate restaurant menu text faithfully and " +
+    "appetizingly. Keep the tone warm and concise. Preserve proper dish names and " +
+    "brand names where a translation would be unnatural. Do not add commentary, notes, " +
+    "or extra fields. Return only the requested translations.";
+
+  const targetNames = targets.map((t) => TRANSLATE_LANGS[t]).join(" and ");
+  const userText =
+    `Source language: ${TRANSLATE_LANGS[source]}.\n` +
+    `Translate the following menu fields into ${targetNames}.\n` +
+    `Return one object per target language keyed by its ISO code (${targets.join(", ")}), ` +
+    `each containing the same fields.\n\n` +
+    `Fields (JSON):\n${JSON.stringify(fields, null, 2)}`;
+
+  const controller =
+    typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timeoutId = controller
+    ? setTimeout(() => controller.abort(), 20000)
+    : null;
+  let resp;
+  try {
+    resp = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": cfg.anthropicApiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      signal: controller?.signal,
+      body: JSON.stringify({
+        model: cfg.translateModel,
+        max_tokens: 2048,
+        system,
+        output_config: { format: { type: "json_schema", schema } },
+        messages: [{ role: "user", content: userText }],
+      }),
+    });
+  } catch (e) {
+    throw httpError(
+      e?.name === "AbortError"
+        ? "El servicio de traducción tardó demasiado en responder."
+        : "No se pudo contactar el servicio de traducción.",
+      502,
+    );
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+
+  const payload = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    const msg = payload?.error?.message || `La API respondió con ${resp.status}`;
+    // Surface auth/config issues as 503, everything else as 502.
+    throw httpError(`Traducción falló: ${msg}`, resp.status === 401 ? 503 : 502);
+  }
+  const text = Array.isArray(payload?.content)
+    ? payload.content.find((b) => b.type === "text")?.text
+    : null;
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw httpError("La traducción devolvió un formato inesperado.", 502);
+  }
+  return parsed;
+}
+
 const server = http.createServer(async (req, res) => {
   try {
     if (!isOriginAllowed(String(req.headers.origin || ""))) {
@@ -470,6 +603,13 @@ const server = http.createServer(async (req, res) => {
         { ok: true },
         { "Set-Cookie": clearCookie(req) },
       );
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/translate") {
+      requireSession(req);
+      const body = await readJsonBody(req);
+      const data = await translateFields(body);
+      return sendJson(res, req, 200, { translations: data });
     }
 
     if (req.method === "POST" && url.pathname === "/api/publish") {

--- a/admin.html
+++ b/admin.html
@@ -1460,6 +1460,7 @@
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.6rem;flex-wrap:wrap;gap:.3rem">
             <strong style="color:var(--gold)">${esc(item.name?.es || "Plato")}</strong>
             <div style="display:flex;gap:.3rem;flex-wrap:wrap">
+              <button class="btn-admin" id="tr-item-${ci}-${ii}" style="padding:.15rem .55rem;font-size:.75rem" onclick="translateItem(${ci},${ii})" title="Traducir el nombre, la descripci\u00f3n y la historia del espa\u00f1ol a ingl\u00e9s y franc\u00e9s">\u2728 Traducir</button>
               <button class="btn-admin" style="padding:.15rem .45rem;font-size:.75rem" onclick="moveItem(${ci},${ii},-1)" title="Subir plato" ${ii === 0 ? "disabled" : ""}>\u25b2</button>
               <button class="btn-admin" style="padding:.15rem .45rem;font-size:.75rem" onclick="moveItem(${ci},${ii},1)" title="Bajar plato" ${ii === (menuData.categories[ci]?.items || []).length - 1 ? "disabled" : ""}>\u25bc</button>
               <button class="btn-admin" style="padding:.15rem .45rem;font-size:.75rem" onclick="duplicateItem(${ci},${ii})" title="Duplicar plato">\u29c9</button>
@@ -1588,6 +1589,84 @@
           item[parts[0]][parts[1]] = value;
         }
         markDirty("menu");
+      }
+
+      // ── Auto-translation (Phase B) ──
+      // Calls the Admin API, which proxies the Claude API server-side, to
+      // translate the given Spanish fields into English and French.
+      // `fields` is { fieldName: spanishText }. Returns { en: {...}, fr: {...} }.
+      async function translateFromSpanish(fields) {
+        const data = await apiFetch("/api/translate", {
+          method: "POST",
+          body: JSON.stringify({
+            source: "es",
+            targets: ["en", "fr"],
+            fields,
+          }),
+        });
+        return data?.translations || {};
+      }
+
+      function withTranslateButton(btnId, fn) {
+        return (async () => {
+          const btn = document.getElementById(btnId);
+          const original = btn ? btn.textContent : "";
+          if (btn) {
+            btn.disabled = true;
+            btn.textContent = "⏳ Traduciendo…";
+          }
+          try {
+            await fn();
+          } catch (e) {
+            alert("No se pudo traducir: " + e.message);
+          } finally {
+            if (btn) {
+              btn.disabled = false;
+              btn.textContent = original || "✨ Traducir";
+            }
+          }
+        })();
+      }
+
+      // Multilingual text fields on a dish that we auto-translate.
+      const ITEM_TRANSLATABLE = [
+        "name",
+        "description",
+        "story",
+        "frenchInfluence",
+        "photoAlt",
+      ];
+
+      async function translateItem(ci, ii) {
+        const item = menuData.categories[ci]?.items?.[ii];
+        if (!item) return;
+        await withTranslateButton(`tr-item-${ci}-${ii}`, async () => {
+          const fields = {};
+          ITEM_TRANSLATABLE.forEach((f) => {
+            const es = item[f]?.es;
+            if (typeof es === "string" && es.trim()) fields[f] = es;
+          });
+          if (!Object.keys(fields).length) {
+            alert("Escribe primero el texto en español.");
+            return;
+          }
+          const tr = await translateFromSpanish(fields);
+          const block = document.getElementById(`item-block-${ci}-${ii}`);
+          ["en", "fr"].forEach((lang) => {
+            const t = tr[lang];
+            if (!t) return;
+            ITEM_TRANSLATABLE.forEach((f) => {
+              if (typeof t[f] !== "string") return;
+              if (!item[f]) item[f] = {};
+              item[f][lang] = t[f];
+              // Update the visible input/textarea in place (no re-render, so
+              // the open category and scroll position are preserved).
+              const el = block?.querySelector(`[oninput*="${f}.${lang}"]`);
+              if (el) el.value = t[f];
+            });
+          });
+          markDirty("menu");
+        });
       }
 
       function setItemList(ci, ii, field, value) {


### PR DESCRIPTION
Phase B of the pilot-feedback program — addresses Pierre's "I had to type all three languages" feedback.

## What it does
- **Backend** (`admin-api/server.js`): new session-protected `POST /api/translate` that proxies the **Claude API** server-side (key never reaches the browser). Strict JSON-schema output, menu-tuned system prompt (French-Costa Rican bistro). Default model `claude-haiku-4-5` (cheap), overridable via `LV_TRANSLATE_MODEL`.
- **Admin** (`admin.html`): a **"✨ Traducir"** button on each dish translates name / description / story / frenchInfluence / photoAlt from Spanish → English + French, filling the fields **in place** for the owner to review before publishing.
- Graceful degradation: if `LV_ANTHROPIC_API_KEY` is unset, the endpoint returns a clear "not configured" message and nothing else breaks.

## ⚠️ Required to activate
Set **`LV_ANTHROPIC_API_KEY`** on Railway (key from console.anthropic.com). The frontend button ships dormant until then.

## Test plan
- [x] server.js / admin.html syntax checks
- [x] Frontend (mocked API): button sends `{source:es, targets:[en,fr], fields:{...}}` and fills EN/FR inputs in place without collapsing the open category
- [x] Route returns 401 without a session (auth boundary)
- [ ] After key + Railway deploy: real translation, spot-check French quality, verify key never reaches the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)