### PR TITLE
Phases C–F: mobile UX, multilingual SEO, accessibility, reliability

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -158,6 +158,41 @@
         font-size: 0.72rem;
         padding: 0.2rem 0.5rem;
       }
+      .item-more {
+        margin-top: 0.6rem;
+        border-top: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+        padding-top: 0.4rem;
+      }
+      .item-more-summary {
+        cursor: pointer;
+        font-size: 0.82rem;
+        font-weight: 600;
+        opacity: 0.85;
+        padding: 0.5rem 0.25rem;
+        list-style: none;
+        user-select: none;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+      .item-more-summary::-webkit-details-marker {
+        display: none;
+      }
+      .item-more-summary::before {
+        content: "▸";
+        transition: transform 0.15s ease;
+      }
+      .item-more[open] > .item-more-summary::before {
+        transform: rotate(90deg);
+      }
+      .item-more-summary:hover,
+      .item-more-summary:focus-visible {
+        opacity: 1;
+        outline: 2px solid var(--accent, #e53888);
+        outline-offset: 2px;
+        border-radius: 6px;
+      }
     </style>
   </head>
   <body>
@@ -1491,6 +1526,16 @@
           </div>
           <label class="admin-label">Descripción FR</label>
           <textarea class="admin-textarea" rows="2" oninput="setItemField(${ci},${ii},'description.fr',this.value)">${esc(item.description?.fr || "")}</textarea>
+          <label class="admin-label">Precio (₡)</label>
+          <input class="admin-input" type="number" inputmode="numeric" value="${esc(item.price || "")}" oninput="setItemField(${ci},${ii},'price',this.value)">
+          <label class="admin-label">Imagen</label>
+          <div class="img-field-row">
+            <input class="admin-input" id="img-url-${ci}-${ii}" value="${esc(item.image || "")}" placeholder="https:// o subir 📷" oninput="setItemField(${ci},${ii},'image',this.value);updateItemImg(${ci},${ii},this.value)">
+            <button class="btn-admin btn-upload-photo" type="button" title="Subir foto" onclick="openPhotoEditor({slug:${esc(JSON.stringify(item.id || "foto"))},aspectRatio:4/3,maxDim:1200,onSuccess:p=>peSetItemImage(${ci},${ii},p)})">📷</button>
+          </div>
+          <img id="img-${ci}-${ii}" class="img-preview" src="" alt="" style="${item.image ? "" : "display:none"}">
+          <details class="item-more">
+            <summary class="item-more-summary">Más detalles — historia, etiquetas, foto, alérgenos…</summary>
           <div class="item-row-2">
             <div>
               <label class="admin-label">Historia ES</label>
@@ -1531,11 +1576,7 @@
           </div>
           <label class="admin-label">Pairings (CSV IDs)</label>
           <input class="admin-input" value="${esc((item.pairings || []).join(","))}" placeholder="crepas,papas" oninput="setItemList(${ci},${ii},'pairings',this.value)">
-          <div class="item-row-3">
-            <div>
-              <label class="admin-label">Precio (₡)</label>
-              <input class="admin-input" type="number" value="${esc(item.price || "")}" oninput="setItemField(${ci},${ii},'price',this.value)">
-            </div>
+          <div class="item-row-2">
             <div>
               <label class="admin-label">Badge texto</label>
               <input class="admin-input" value="${esc(item.badgeText || "")}" placeholder="Nuevo, Temporada…" oninput="setItemField(${ci},${ii},'badgeText',this.value)">
@@ -1545,12 +1586,6 @@
               <input class="admin-input" value="${esc(item.id || "")}" oninput="setItemField(${ci},${ii},'id',this.value)">
             </div>
           </div>
-          <label class="admin-label">Imagen</label>
-          <div class="img-field-row">
-            <input class="admin-input" id="img-url-${ci}-${ii}" value="${esc(item.image || "")}" placeholder="https:// o subir 📷" oninput="setItemField(${ci},${ii},'image',this.value);updateItemImg(${ci},${ii},this.value)">
-            <button class="btn-admin btn-upload-photo" type="button" title="Subir foto" onclick="openPhotoEditor({slug:${esc(JSON.stringify(item.id || "foto"))},aspectRatio:4/3,maxDim:1200,onSuccess:p=>peSetItemImage(${ci},${ii},p)})">📷</button>
-          </div>
-          <img id="img-${ci}-${ii}" class="img-preview" src="" alt="" style="${item.image ? "" : "display:none"}">
           <div class="item-row-3" style="margin-top:.4rem">
             <div>
               <label class="admin-label" style="margin-top:.5rem">Alt texto ES</label>
@@ -1575,6 +1610,7 @@
           </div>
           <label class="admin-label">Alérgenos</label>
           <div class="allergen-grid">${allergenChips}</div>
+          </details>
         </div>`;
       }
 
@@ -2583,7 +2619,7 @@
       }
 
       /* ── Photo Upload Engine (Phase 1) ── */
-      function safeFilename(slug) {
+      function safeFilename(slug, ext = ".webp") {
         return (
           (slug || "foto")
             .replace(/[^a-z0-9]/gi, "-")
@@ -2593,8 +2629,33 @@
             .slice(0, 40) +
           "-" +
           Date.now() +
-          ".webp"
+          ext
         );
+      }
+
+      // Encode a canvas to WebP, falling back to JPEG where WebP encoding is
+      // unsupported (e.g. older iOS Safari, where toBlob silently yields PNG).
+      function canvasToUploadBlob(canvas, quality) {
+        const toBlob = (type) =>
+          new Promise((resolve) => canvas.toBlob((b) => resolve(b), type, quality));
+        return (async () => {
+          const webp = await toBlob("image/webp");
+          if (webp && webp.type === "image/webp") {
+            return { blob: webp, ext: ".webp" };
+          }
+          const jpeg = await toBlob("image/jpeg");
+          if (jpeg) return { blob: jpeg, ext: ".jpg" };
+          throw new Error("No se pudo convertir la imagen");
+        })();
+      }
+
+      function blobToBase64(blob) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = (e) => resolve(e.target.result.split(",")[1]);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
       }
 
       async function uploadImageToGitHub(base64Data, filename) {
@@ -2768,23 +2829,9 @@
           const ctx = finalCanvas.getContext("2d");
           ctx.filter = `brightness(${1 + b / 100}) contrast(${1 + c / 100})`;
           ctx.drawImage(cropped, 0, 0);
-          const base64 = await new Promise((resolve, reject) => {
-            finalCanvas.toBlob(
-              (blob) => {
-                if (!blob) {
-                  reject(new Error("No se pudo convertir la imagen"));
-                  return;
-                }
-                const reader = new FileReader();
-                reader.onload = (e) => resolve(e.target.result.split(",")[1]);
-                reader.onerror = reject;
-                reader.readAsDataURL(blob);
-              },
-              "image/webp",
-              0.85,
-            );
-          });
-          const filename = safeFilename(peContext.slug || "foto");
+          const { blob, ext } = await canvasToUploadBlob(finalCanvas, 0.85);
+          const base64 = await blobToBase64(blob);
+          const filename = safeFilename(peContext.slug || "foto", ext);
           const ctx2 = peContext; // capture before closePhotoEditor clears it
           const path = await uploadImageToGitHub(base64, filename);
           closePhotoEditor();
@@ -2949,7 +2996,19 @@
       }
 
       /* ── Init ── */
+      // Self-heal a stale saved API base: if the page ships a configured base
+      // and localStorage holds a different (likely outdated) one, trust config.
+      function reconcileApiBase() {
+        const configured = normalizeApiBase(window.LV_ADMIN_API_BASE || "");
+        if (!configured) return;
+        const stored = normalizeApiBase(
+          localStorage.getItem(API_BASE_STORAGE_KEY) || "",
+        );
+        if (stored && stored !== configured) saveApiBase(configured);
+      }
+
       (async function init() {
+        reconcileApiBase();
         renderAuthCard();
         peSetupDragDrop();
         await discoverApiBase();

--- a/app.js
+++ b/app.js
@@ -390,6 +390,7 @@ function applyConfig(cfg) {
   const ld = {
     '@context':'https://schema.org',
     '@type':'Restaurant',
+    inLanguage: lang,
     name: cfg.restaurantName || 'Las Veraneras',
     description: localized({ es: cfg.tagline, en: cfg.taglineEn, fr: cfg.taglineFr }, cfg.tagline || ''),
     address: { '@type':'PostalAddress', addressLocality:'Las Vueltas de Tucurrique', addressRegion:'Cartago', addressCountry:'CR', streetAddress: cfg.address || '' },
@@ -443,10 +444,26 @@ function setLang(l) {
   lang = l;
   localStorage.setItem('lv-lang', l);
   document.documentElement.lang = l;
+  // Keep SEO language signals in sync with the active language
+  const ogLocale = $('og-locale');
+  if (ogLocale) ogLocale.setAttribute('content', l === 'es' ? 'es_CR' : l);
+  const ldEl = $('structured-data');
+  if (ldEl) {
+    try {
+      const ld = JSON.parse(ldEl.textContent || '{}');
+      if (ld && typeof ld === 'object') {
+        ld.inLanguage = l;
+        ldEl.textContent = JSON.stringify(ld);
+      }
+    } catch (e) { /* ignore malformed LD */ }
+  }
   // Update button states
   ['btn-es','btn-en','btn-fr','mob-btn-es','mob-btn-en','mob-btn-fr'].forEach(id => {
     const btn = $(id);
-    if (btn) btn.classList.toggle('active', btn.id.endsWith(l));
+    if (!btn) return;
+    const isActive = btn.id.endsWith(l);
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
   // Update tagline
   const ht = $('hero-tagline');

--- a/index.html
+++ b/index.html
@@ -13,7 +13,14 @@
 <meta property="og:description" content="Cocina tica con oficio francés, veraneras en flor y pedidos por WhatsApp.">
 <meta property="og:image" id="og-image" content="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'%3E%3Cg transform='translate(18,18)'%3E%3Cellipse rx='6' ry='11' fill='%23F72585' transform='rotate(0) translate(0,-6)'/%3E%3Cellipse rx='6' ry='11' fill='%23F72585' transform='rotate(72) translate(0,-6)'/%3E%3Cellipse rx='6' ry='11' fill='%237209B7' transform='rotate(144) translate(0,-6)'/%3E%3Cellipse rx='6' ry='11' fill='%237209B7' transform='rotate(216) translate(0,-6)'/%3E%3Cellipse rx='6' ry='11' fill='%23F72585' transform='rotate(288) translate(0,-6)'/%3E%3Ccircle r='3.5' fill='%23FFD700'/%3E%3C/g%3E%3C/svg%3E">
 <meta property="og:url" content="https://sandgraal.github.io/las-veraneras-menu/">
+<meta property="og:locale" content="es_CR" id="og-locale">
+<meta property="og:locale:alternate" content="en">
+<meta property="og:locale:alternate" content="fr">
 <link rel="canonical" href="https://sandgraal.github.io/las-veraneras-menu/">
+<link rel="alternate" hreflang="es" href="https://sandgraal.github.io/las-veraneras-menu/?lang=es">
+<link rel="alternate" hreflang="en" href="https://sandgraal.github.io/las-veraneras-menu/?lang=en">
+<link rel="alternate" hreflang="fr" href="https://sandgraal.github.io/las-veraneras-menu/?lang=fr">
+<link rel="alternate" hreflang="x-default" href="https://sandgraal.github.io/las-veraneras-menu/">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Las Veraneras | Bistro Franco-Tico en Tucurrique">
 <meta name="twitter:description" content="Cocina tica con oficio francés, veraneras en flor y pedidos por WhatsApp.">
@@ -47,10 +54,10 @@
       <span class="nav-brand">Las Veraneras</span>
     </a>
     <div class="nav-center">
-      <div class="lang-toggle">
-        <button id="btn-es" class="lang-btn active" onclick="setLang('es')">ES</button>
-        <button id="btn-en" class="lang-btn" onclick="setLang('en')">EN</button>
-        <button id="btn-fr" class="lang-btn" onclick="setLang('fr')">FR</button>
+      <div class="lang-toggle" role="group" aria-label="Idioma / Language / Langue">
+        <button id="btn-es" class="lang-btn active" aria-pressed="true" lang="es" onclick="setLang('es')">ES</button>
+        <button id="btn-en" class="lang-btn" aria-pressed="false" lang="en" onclick="setLang('en')">EN</button>
+        <button id="btn-fr" class="lang-btn" aria-pressed="false" lang="fr" onclick="setLang('fr')">FR</button>
       </div>
     </div>
     <div class="nav-right">
@@ -67,10 +74,10 @@
     </div>
   </div>
   <div class="mobile-menu" id="mobile-menu">
-    <div class="lang-toggle mobile-lang">
-      <button id="mob-btn-es" class="lang-btn active" onclick="setLang('es');toggleMobileMenu()">ES</button>
-      <button id="mob-btn-en" class="lang-btn" onclick="setLang('en');toggleMobileMenu()">EN</button>
-      <button id="mob-btn-fr" class="lang-btn" onclick="setLang('fr');toggleMobileMenu()">FR</button>
+    <div class="lang-toggle mobile-lang" role="group" aria-label="Idioma / Language / Langue">
+      <button id="mob-btn-es" class="lang-btn active" aria-pressed="true" lang="es" onclick="setLang('es');toggleMobileMenu()">ES</button>
+      <button id="mob-btn-en" class="lang-btn" aria-pressed="false" lang="en" onclick="setLang('en');toggleMobileMenu()">EN</button>
+      <button id="mob-btn-fr" class="lang-btn" aria-pressed="false" lang="fr" onclick="setLang('fr');toggleMobileMenu()">FR</button>
     </div>
     <a id="mobile-wa" href="#" class="btn-wa-mobile" onclick="handleWaClick(event);toggleMobileMenu()">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>


### PR DESCRIPTION
Final phases of the pilot-feedback expert program. All verified in a browser.

## C — Mobile admin UX (progressive disclosure)
Item editor now shows only Name / Description / Price / Image up front; story, French touch, tags, badge/ID, photo alt, and allergens collapse into a native `<details>` "Más detalles" (keyboard-accessible, zero JS). Big reduction in mobile scrolling. *Verified: price/image outside, advanced fields inside, collapsed by default.*

## D — Multilingual SEO
`hreflang` alternates (es/en/fr/x-default) + `og:locale` in `index.html`; `setLang` keeps `og:locale` and JSON-LD `inLanguage` in sync; existing JSON-LD already emits `Restaurant` + `hasMenu`. *Verified: hreflang set, og:locale and inLanguage track language.*

## E — Accessibility
Language switcher: `role=group`, per-button `aria-pressed` (synced in `setLang`), `aria-label`s, `lang` attributes. Menu images already use `photoAlt`/name `alt`. *Verified: aria-pressed toggles.*

## F — Reliability
- Photo upload: WebP with **JPEG fallback** for older iOS Safari (`canvasToUploadBlob`); filename extension follows actual format. *Verified: WebP happy path.*
- Self-heal a stale `lv-admin-api-base` in localStorage against the configured value on init.

## Test plan
- [x] app.js + admin.html syntax; `<details>` balanced
- [x] Browser: hreflang, og:locale, LD inLanguage, aria-pressed, details collapse, WebP encode, helpers present
- [ ] Post-deploy: spot-check live admin on a phone; validate hreflang with an SEO tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)